### PR TITLE
Add provider parameter to networkAccount.

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -2,6 +2,7 @@ import { ReachAccount, LibFallbackOpts } from "./types";
 import { createReachAPI } from "./reachlib-api";
 import { createConnectorAPI } from "./networks/index.networks";
 import { getStorage, isBrowser } from "./utils/helpers";
+import { Providers } from "./utils/constants";
 
 /** Configure stdlib wallet fallback */
 function setLibFallback(opts?: LibFallbackOpts) {
@@ -27,10 +28,12 @@ export function useWalletConnect() {
 }
 
 /** Connect user Wallet */
-export async function connectUser() {
+export async function connectUser(provider?: string) {
   const { getDefaultAccount } = createReachAPI();
   try {
     const account: ReachAccount = await getDefaultAccount();
+    if(provider)
+      account.networkAccount.provider = provider;
     return hydrateUser(account);
   } catch (e: any) {
     throw e;
@@ -75,10 +78,12 @@ export async function reconnectUser(addr?: string | null) {
   const stdlib = createReachAPI();
   if (addr) {
     useWebWallet();
-    return hydrateUser(await stdlib.connectAccount({ addr }));
+    return hydrateUser(await stdlib.connectAccount({ provider: Providers.MyAlgo, addr }));
   } else {
     useWalletConnect();
-    return hydrateUser(await stdlib.getDefaultAccount());
+    const defaultAccount = await stdlib.getDefaultAccount();
+    defaultAccount.networkAccount.provider = Providers.WalletConnect;
+    return hydrateUser(defaultAccount);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ export type ReachToken = {
 
 /** A reach-connected Network Account representation */
 export type ReachAccount = { [x: string]: any } & {
-  networkAccount: { addr?: string; address?: string; [x: string]: any };
+  networkAccount: { provider?: string; addr?: string; address?: string; [x: string]: any };
   /** @deprecated - Use `reachAccount.contract(backend)` instead */
   attach<T extends BackendModule>(
     backend: T,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,4 @@
+export const Providers: any = {
+  WalletConnect: "WalletConnect",
+  MyAlgo: "MyAlgo",
+};


### PR DESCRIPTION
It can be useful to know the wallet provider from the ReachAccount's networkAccount object. In this PR the ReachAccount now knows what is its wallet provider (MyAlgo or WalletConnect).